### PR TITLE
Use "ember-cli-import-polyfill" for import() call in "included" hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 /* jshint node: true */
 'use strict';
 
+// Polyfill the Addon.import() method introduced by ember-cli@2.7.0
+require('ember-cli-import-polyfill');
+
 /*
  * The `index.js` file is the main entry point for all Ember CLI addons.  The
  * object we export from this file is turned into an Addon class
@@ -33,8 +36,8 @@ module.exports = {
    * which allows us to use the `import()` method to tell it to include a file
    * from our `vendor` tree into the final built app.
    */
-  included: function(app) {
-    app.import('vendor/fetch.js');
+  included: function() {
+    this.import('vendor/fetch.js');
   },
 
   /*

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "broccoli-stew": "^1.0.4",
     "broccoli-templater": "^1.0.0",
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-import-polyfill": "^0.1.0",
     "node-fetch": "^1.3.3",
     "whatwg-fetch": "^0.11.0"
   },


### PR DESCRIPTION
This PR changes the `included` hook to use the new "[uniform import API](https://github.com/ember-cli/ember-cli/pull/5877)" in Ember CLI provided by the "ember-cli-import-polyfill" addon.

Resolves #5 and continues #6.

/cc @ef4 @stefanpenner 
