### PR TITLE
README: fetch-mock is a npm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ import 'ember-network/fetch';
 Because we will be mocking the global `fetch`, having a local reference will miss out on the mocked version. Now we are ready for mocking:
 
 ```
-ember install fetch-mock ember-browserify
+npm install fetch-mock
+ember install ember-browserify
 ```
 
 Now, inside of any acceptance tests, you can mock any network traffic with ease:


### PR DESCRIPTION
I got this error trying to install fetch-mock using `ember install`:

```
$ ember install fetch-mock
Installed packages for tooling via npm.
Install failed. Could not find addon with name: fetch-mock
```

This PR changes the README to tell the user to get [fetch-mock](https://github.com/wheresrhys/fetch-mock) using npm.